### PR TITLE
Add package lock file to prquantifier

### DIFF
--- a/.prquantifier
+++ b/.prquantifier
@@ -2,6 +2,7 @@ Included:
 Excluded:
 - '*.csproj'
 - '*.prquantifier'
+- 'package-lock.json'
 GitOperationType:
 - Add
 - Delete


### PR DESCRIPTION
Will generate an example using this for demo. This is to exclude nodejs package lock file.