### PR TITLE
Add telemetry for github events

### DIFF
--- a/src/Clients/PullRequestQuantifier.GitHub.Client.Tests/TestServer/InMemoryEventBus.cs
+++ b/src/Clients/PullRequestQuantifier.GitHub.Client.Tests/TestServer/InMemoryEventBus.cs
@@ -2,6 +2,7 @@ namespace PullRequestQuantifier.GitHub.Client.Tests.TestServer
 {
     using System;
     using System.Collections.Generic;
+    using System.Runtime.CompilerServices;
     using System.Threading;
     using System.Threading.Tasks;
     using Newtonsoft.Json.Linq;
@@ -23,7 +24,7 @@ namespace PullRequestQuantifier.GitHub.Client.Tests.TestServer
         }
 
         public Task SubscribeAsync(
-            Func<string, Task> messageHandler,
+            Func<string, DateTimeOffset, Task> messageHandler,
             Func<Exception, Task> errorHandler,
             CancellationToken cancellationToken)
         {

--- a/src/Clients/PullRequestQuantifier.GitHub.Client/Controllers/GitHubWebhookController.cs
+++ b/src/Clients/PullRequestQuantifier.GitHub.Client/Controllers/GitHubWebhookController.cs
@@ -71,6 +71,7 @@
                 Enum.TryParse(action, true, out GitHubEventActions parsedAction) &&
                 (parsedEvent & parsedAction) == parsedAction)
             {
+                payload["eventType"] = eventType;
                 await eventBus.WriteAsync(payload);
             }
 

--- a/src/Clients/PullRequestQuantifier.GitHub.Client/Events/GitHubEventHost.cs
+++ b/src/Clients/PullRequestQuantifier.GitHub.Client/Events/GitHubEventHost.cs
@@ -1,40 +1,35 @@
 ﻿namespace PullRequestQuantifier.GitHub.Client.Events
 {
     using System;
-    using System.Drawing;
-    using System.IO;
-    using System.Text;
+    using System.Collections.Generic;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Extensions.Hosting;
-    using Octokit;
-    using PullRequestQuantifier.Abstractions.Core;
-    using PullRequestQuantifier.Abstractions.Git;
-    using PullRequestQuantifier.Client.Extensions;
-    using PullRequestQuantifier.Client.QuantifyClient;
-    using PullRequestQuantifier.GitHub.Client.GitHubClient;
+    using Newtonsoft.Json.Linq;
+    using PullRequestQuantifier.GitHub.Client.Models;
     using PullRequestQuantifier.GitHub.Client.Telemetry;
 
     public class GitHubEventHost : IHostedService
     {
         private readonly IEventBus eventBus;
         private readonly IAppTelemetry appTelemetry;
-        private readonly IGitHubClientAdapterFactory gitHubClientAdapterFactory;
+        private readonly IDictionary<GitHubEventActions, IGitHubEventHandler> gitHubEventHandlers;
 
         public GitHubEventHost(
             IEventBus eventBus,
             IAppTelemetry appTelemetry,
-            IGitHubClientAdapterFactory gitHubClientAdapterFactory)
+            IEnumerable<IGitHubEventHandler> gitHubEventHandlers)
         {
             this.eventBus = eventBus;
             this.appTelemetry = appTelemetry;
-            this.gitHubClientAdapterFactory = gitHubClientAdapterFactory;
+            this.gitHubEventHandlers = gitHubEventHandlers.ToDictionary(h => h.EventType);
         }
 
         public async Task StartAsync(CancellationToken cancellationToken)
         {
             await eventBus.SubscribeAsync(
-                QuantifyPullRequest,
+                HandleGitHubEvent,
                 ErrorHandler,
                 cancellationToken);
         }
@@ -44,126 +39,32 @@
             return Task.CompletedTask;
         }
 
-        private async Task QuantifyPullRequest(string pullRequestEvent)
+        private async Task HandleGitHubEvent(string gitHubEvent)
         {
-            var payload =
-                new Octokit.Internal.SimpleJsonSerializer().Deserialize<PullRequestEventPayload>(pullRequestEvent);
-
-            var gitHubClientAdapter =
-                await gitHubClientAdapterFactory.GetGitHubClientAdapterAsync(payload.Installation.Id);
-
-            // get pull request
-            var pullRequest = await gitHubClientAdapter.GetPullRequestAsync(
-                payload.Repository.Id,
-                payload.PullRequest.Number);
-
-            // get pull request files
-            var pullRequestFiles = await gitHubClientAdapter.GetPullRequestFilesAsync(
-                payload.Repository.Id,
-                payload.PullRequest.Number);
-
-            // convert to quantifier input
-            var quantifierInput = new QuantifierInput();
-            foreach (var pullRequestFile in pullRequestFiles)
+            var eventJtoken = JToken.Parse(gitHubEvent);
+            if (!Enum.TryParse(
+                eventJtoken["eventType"].ToString(),
+                true,
+                out GitHubEventActions parsedEvent))
             {
-                if (pullRequestFile.Patch == null)
-                {
-                    continue;
-                }
-
-                var changeType = GitChangeType.Modified;
-                switch (pullRequestFile.Status)
-                {
-                    case "modified":
-                        break;
-                    case "added":
-                        changeType = GitChangeType.Added;
-                        break;
-                    case "deleted":
-                        changeType = GitChangeType.Deleted;
-                        break;
-                }
-
-                var fileExtension = !string.IsNullOrWhiteSpace(pullRequestFile.FileName)
-                    ? new FileInfo(pullRequestFile.FileName).Extension
-                    : string.Empty;
-                var gitFilePatch = new GitFilePatch(
-                    pullRequestFile.FileName,
-                    fileExtension)
-                {
-                    ChangeType = changeType,
-                    AbsoluteLinesAdded = pullRequestFile.Additions,
-                    AbsoluteLinesDeleted = pullRequestFile.Deletions,
-                    DiffContent = pullRequestFile.Patch,
-                };
-                quantifierInput.Changes.Add(gitFilePatch);
+                return;
             }
 
-            // get context if present
-            string context = null;
-            try
+            if (gitHubEventHandlers.TryGetValue(parsedEvent, out var selectedEventHandler))
             {
-                var rawContext = await gitHubClientAdapter.GetRawFileAsync(
-                    payload.Repository.Owner.Login,
-                    payload.Repository.Name,
-                    "/prquantifier.yaml");
-                context = Encoding.UTF8.GetString(rawContext);
+                await selectedEventHandler.HandleEvent(gitHubEvent);
             }
-            catch (NotFoundException)
+            else
             {
+                // this should never happen
+                // there must always be a handler for an accepted eventType
+                // TODO: log
             }
-            catch
-            {
-                // ignored
-            }
-
-            var quantifyClient = new QuantifyClient(context);
-            var quantifierClientResult = await quantifyClient.Compute(quantifierInput);
-
-            // create a new label in the repository if doesn't exist
-            try
-            {
-                var existingLabel = await gitHubClientAdapter.GetLabelAsync(
-                    payload.Repository.Id,
-                    quantifierClientResult.Label);
-            }
-            catch (NotFoundException)
-            {
-                // create new label
-                var color = Color.FromName(quantifierClientResult.Color);
-                await gitHubClientAdapter.CreateLabelAsync(
-                    payload.Repository.Id,
-                    new NewLabel(quantifierClientResult.Label, ConvertToHex(color)));
-            }
-
-            // apply label to pull request
-            await gitHubClientAdapter.ApplyLabelAsync(
-                payload.Repository.Id,
-                payload.PullRequest.Number,
-                new[] { quantifierClientResult.Label });
-
-            // create a comment on the issue
-            var defaultBranch = payload.Repository.DefaultBranch;
-            var quantifierContextLink = $"{payload.Repository.HtmlUrl}/blob/{defaultBranch}/prquantifier.yaml";
-            var comment = await quantifierClientResult.ToMarkdownCommentAsync(
-                payload.Repository.HtmlUrl,
-                quantifierContextLink,
-                payload.PullRequest.HtmlUrl,
-                payload.PullRequest.User.Login);
-            await gitHubClientAdapter.CreateIssueCommentAsync(
-                payload.Repository.Id,
-                payload.PullRequest.Number,
-                comment);
         }
 
         private Task ErrorHandler(Exception exception)
         {
             return Task.CompletedTask;
-        }
-
-        private string ConvertToHex(Color c)
-        {
-            return c.R.ToString("X2") + c.G.ToString("X2") + c.B.ToString("X2");
         }
     }
 }

--- a/src/Clients/PullRequestQuantifier.GitHub.Client/Events/IEventBus.cs
+++ b/src/Clients/PullRequestQuantifier.GitHub.Client/Events/IEventBus.cs
@@ -1,6 +1,7 @@
 namespace PullRequestQuantifier.GitHub.Client.Events
 {
     using System;
+    using System.Runtime.CompilerServices;
     using System.Threading;
     using System.Threading.Tasks;
     using Newtonsoft.Json.Linq;
@@ -10,7 +11,7 @@ namespace PullRequestQuantifier.GitHub.Client.Events
         Task WriteAsync(JObject payload);
 
         Task SubscribeAsync(
-            Func<string, Task> messageHandler,
+            Func<string, DateTimeOffset, Task> messageHandler,
             Func<Exception, Task> errorHandler,
             CancellationToken cancellationToken);
     }

--- a/src/Clients/PullRequestQuantifier.GitHub.Client/Events/IGitHubEventHandler.cs
+++ b/src/Clients/PullRequestQuantifier.GitHub.Client/Events/IGitHubEventHandler.cs
@@ -1,0 +1,12 @@
+namespace PullRequestQuantifier.GitHub.Client.Events
+{
+    using System.Threading.Tasks;
+    using PullRequestQuantifier.GitHub.Client.Models;
+
+    public interface IGitHubEventHandler
+    {
+        GitHubEventActions EventType { get; }
+
+        Task HandleEvent(string gitHubEvent);
+    }
+}

--- a/src/Clients/PullRequestQuantifier.GitHub.Client/Events/InstallationEventHandler.cs
+++ b/src/Clients/PullRequestQuantifier.GitHub.Client/Events/InstallationEventHandler.cs
@@ -1,0 +1,24 @@
+namespace PullRequestQuantifier.GitHub.Client.Events
+{
+    using System.Threading.Tasks;
+    using PullRequestQuantifier.GitHub.Client.GitHubClient;
+    using PullRequestQuantifier.GitHub.Client.Models;
+
+    public class InstallationEventHandler : IGitHubEventHandler
+    {
+        private readonly IGitHubClientAdapterFactory gitHubClientAdapterFactory;
+
+        public InstallationEventHandler(IGitHubClientAdapterFactory gitHubClientAdapterFactory)
+        {
+            this.gitHubClientAdapterFactory = gitHubClientAdapterFactory;
+        }
+
+        public GitHubEventActions EventType { get; } = GitHubEventActions.Installation;
+
+        public Task HandleEvent(string gitHubEvent)
+        {
+            // TODO: handle installation events
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Clients/PullRequestQuantifier.GitHub.Client/Events/PullRequestEventHandler.cs
+++ b/src/Clients/PullRequestQuantifier.GitHub.Client/Events/PullRequestEventHandler.cs
@@ -1,0 +1,143 @@
+namespace PullRequestQuantifier.GitHub.Client.Events
+{
+    using System.Drawing;
+    using System.IO;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Octokit;
+    using PullRequestQuantifier.Abstractions.Core;
+    using PullRequestQuantifier.Abstractions.Git;
+    using PullRequestQuantifier.Client.Extensions;
+    using PullRequestQuantifier.Client.QuantifyClient;
+    using PullRequestQuantifier.GitHub.Client.GitHubClient;
+    using PullRequestQuantifier.GitHub.Client.Models;
+
+    public class PullRequestEventHandler : IGitHubEventHandler
+    {
+        private readonly IGitHubClientAdapterFactory gitHubClientAdapterFactory;
+
+        public PullRequestEventHandler(IGitHubClientAdapterFactory gitHubClientAdapterFactory)
+        {
+            this.gitHubClientAdapterFactory = gitHubClientAdapterFactory;
+        }
+
+        public GitHubEventActions EventType { get; } = GitHubEventActions.Pull_Request;
+
+        public async Task HandleEvent(string gitHubEvent)
+        {
+            var payload =
+                new Octokit.Internal.SimpleJsonSerializer().Deserialize<PullRequestEventPayload>(gitHubEvent);
+
+            var gitHubClientAdapter =
+                await gitHubClientAdapterFactory.GetGitHubClientAdapterAsync(payload.Installation.Id);
+
+            // get pull request
+            var pullRequest = await gitHubClientAdapter.GetPullRequestAsync(
+                payload.Repository.Id,
+                payload.PullRequest.Number);
+
+            // get pull request files
+            var pullRequestFiles = await gitHubClientAdapter.GetPullRequestFilesAsync(
+                payload.Repository.Id,
+                payload.PullRequest.Number);
+
+            // convert to quantifier input
+            var quantifierInput = new QuantifierInput();
+            foreach (var pullRequestFile in pullRequestFiles)
+            {
+                if (pullRequestFile.Patch == null)
+                {
+                    continue;
+                }
+
+                var changeType = GitChangeType.Modified;
+                switch (pullRequestFile.Status)
+                {
+                    case "modified":
+                        break;
+                    case "added":
+                        changeType = GitChangeType.Added;
+                        break;
+                    case "deleted":
+                        changeType = GitChangeType.Deleted;
+                        break;
+                }
+
+                var fileExtension = !string.IsNullOrWhiteSpace(pullRequestFile.FileName)
+                    ? new FileInfo(pullRequestFile.FileName).Extension
+                    : string.Empty;
+                var gitFilePatch = new GitFilePatch(
+                    pullRequestFile.FileName,
+                    fileExtension)
+                {
+                    ChangeType = changeType,
+                    AbsoluteLinesAdded = pullRequestFile.Additions,
+                    AbsoluteLinesDeleted = pullRequestFile.Deletions,
+                    DiffContent = pullRequestFile.Patch,
+                };
+                quantifierInput.Changes.Add(gitFilePatch);
+            }
+
+            // get context if present
+            string context = null;
+            try
+            {
+                var rawContext = await gitHubClientAdapter.GetRawFileAsync(
+                    payload.Repository.Owner.Login,
+                    payload.Repository.Name,
+                    "/prquantifier.yaml");
+                context = Encoding.UTF8.GetString(rawContext);
+            }
+            catch (NotFoundException)
+            {
+            }
+            catch
+            {
+                // ignored
+            }
+
+            var quantifyClient = new QuantifyClient(context);
+            var quantifierClientResult = await quantifyClient.Compute(quantifierInput);
+
+            // create a new label in the repository if doesn't exist
+            try
+            {
+                var existingLabel = await gitHubClientAdapter.GetLabelAsync(
+                    payload.Repository.Id,
+                    quantifierClientResult.Label);
+            }
+            catch (NotFoundException)
+            {
+                // create new label
+                var color = Color.FromName(quantifierClientResult.Color);
+                await gitHubClientAdapter.CreateLabelAsync(
+                    payload.Repository.Id,
+                    new NewLabel(quantifierClientResult.Label, ConvertToHex(color)));
+            }
+
+            // apply label to pull request
+            await gitHubClientAdapter.ApplyLabelAsync(
+                payload.Repository.Id,
+                payload.PullRequest.Number,
+                new[] { quantifierClientResult.Label });
+
+            // create a comment on the issue
+            var defaultBranch = payload.Repository.DefaultBranch;
+            var quantifierContextLink = $"{payload.Repository.HtmlUrl}/blob/{defaultBranch}/prquantifier.yaml";
+            var comment = await quantifierClientResult.ToMarkdownCommentAsync(
+                payload.Repository.HtmlUrl,
+                quantifierContextLink,
+                payload.PullRequest.HtmlUrl,
+                payload.PullRequest.User.Login);
+            await gitHubClientAdapter.CreateIssueCommentAsync(
+                payload.Repository.Id,
+                payload.PullRequest.Number,
+                comment);
+        }
+
+        private string ConvertToHex(Color c)
+        {
+            return c.R.ToString("X2") + c.G.ToString("X2") + c.B.ToString("X2");
+        }
+    }
+}

--- a/src/Clients/PullRequestQuantifier.GitHub.Client/Models/GitHubEventActions.cs
+++ b/src/Clients/PullRequestQuantifier.GitHub.Client/Models/GitHubEventActions.cs
@@ -12,7 +12,10 @@ namespace PullRequestQuantifier.GitHub.Client.Models
         Synchronize = 1 << 1,
         Reopened = 1 << 2,
         Created = 1 << 3,
+        Added = 1 << 4,
+        Deleted = 1 << 5,
+        Removed = 1 << 6,
         Pull_Request = Opened | Reopened | Synchronize,
-        Installation = Created
+        Installation = Created | Added | Deleted | Removed
     }
 }

--- a/src/Clients/PullRequestQuantifier.GitHub.Client/Registrar.cs
+++ b/src/Clients/PullRequestQuantifier.GitHub.Client/Registrar.cs
@@ -19,23 +19,30 @@ namespace PullRequestQuantifier.GitHub.Client
             serviceCollection.Configure<GitHubAppSettings>(configuration.GetSection(nameof(GitHubAppSettings)));
             serviceCollection.Configure<AzureServiceBusSettings>(
                 configuration.GetSection(nameof(AzureServiceBusSettings)));
-            serviceCollection.AddSingleton<IGitHubJwtFactory>(sp =>
-            {
-                // register a GitHubJwtFactory used to create tokens to access github for a particular org on behalf  of the  app
-                var gitHubAppSettings = sp.GetRequiredService<IOptions<GitHubAppSettings>>().Value;
-                ArgumentCheck.ParameterIsNotNull(gitHubAppSettings, nameof(gitHubAppSettings));
+            serviceCollection.AddSingleton<IGitHubJwtFactory>(
+                sp =>
+                {
+                    // register a GitHubJwtFactory used to create tokens to access github for a particular org on behalf  of the  app
+                    var gitHubAppSettings = sp.GetRequiredService<IOptions<GitHubAppSettings>>().Value;
+                    ArgumentCheck.ParameterIsNotNull(gitHubAppSettings, nameof(gitHubAppSettings));
 
-                // Use GitHubJwt library to create the GitHubApp Jwt Token using our private certificate PEM file
-                return new GitHubJwtFactory(
-                    new StringPrivateKeySource(gitHubAppSettings.PrivateKey),
-                    new GitHubJwtFactoryOptions
-                    {
-                        AppIntegrationId = int.Parse(gitHubAppSettings.Id), // The GitHub App Id
-                        ExpirationSeconds = 600 // 10 minutes is the maximum time allowed
-                    });
-            });
+                    // Use GitHubJwt library to create the GitHubApp Jwt Token using our private certificate PEM file
+                    return new GitHubJwtFactory(
+                        new StringPrivateKeySource(gitHubAppSettings.PrivateKey),
+                        new GitHubJwtFactoryOptions
+                        {
+                            AppIntegrationId = int.Parse(gitHubAppSettings.Id), // The GitHub App Id
+                            ExpirationSeconds = 600 // 10 minutes is the maximum time allowed
+                        });
+                });
             serviceCollection.AddSingleton<IGitHubClientAdapterFactory, GitHubClientAdapterFactory>();
             serviceCollection.TryAddSingleton<IEventBus, AzureServiceBus>();
+            serviceCollection.TryAddEnumerable(
+                new[]
+                {
+                    ServiceDescriptor.Singleton<IGitHubEventHandler, PullRequestEventHandler>(),
+                    ServiceDescriptor.Singleton<IGitHubEventHandler, InstallationEventHandler>()
+                });
             serviceCollection.AddHostedService<GitHubEventHost>();
 
             serviceCollection.AddApmForWebHost(configuration, typeof(Registrar).Namespace);

--- a/src/Clients/PullRequestQuantifier.GitHub.Client/appsettings.json
+++ b/src/Clients/PullRequestQuantifier.GitHub.Client/appsettings.json
@@ -2,8 +2,8 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
+      "Microsoft.AspNetCore.Mvc": "Warning",
+      "Microsoft.AspNetCore.Hosting.Internal.WebHost": "Warning"
     }
   },
   "AllowedHosts": "*"


### PR DESCRIPTION
- Add timing and quantifier result telemetry for github events
- Split github event host into handlers for different types of events

TODO: Handle installation event and add telemetry for that.
Perhaps push the quantifier results to azure table also for long term storage. AppInsights can only store for limited time.