### PR TITLE
Add microsoft form for feedback

### DIFF
--- a/.github/workflows/feedback_service.yml
+++ b/.github/workflows/feedback_service.yml
@@ -3,7 +3,7 @@ name: Build and Deploy feedback service
 on:
   workflow_dispatch:
   push:
-    # branches: [ main ]
+    branches: [ main ]
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/feedback_service.yml
+++ b/.github/workflows/feedback_service.yml
@@ -1,0 +1,35 @@
+name: Build and Deploy feedback service
+
+on:
+  workflow_dispatch:
+  push:
+    # branches: [ main ]
+
+jobs:
+  build-and-deploy:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+          fetch-depth: 0
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.100
+    - name: Install dependencies
+      run: dotnet restore src/PullRequestQuantifier.Feedback.Service/PullRequestQuantifier.Feedback.Service.csproj
+      env:
+        DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+    - name: Build
+      run: dotnet build src/PullRequestQuantifier.Feedback.Service/PullRequestQuantifier.Feedback.Service.csproj --configuration Release --no-restore
+    - name: dotnet publish
+      run: dotnet publish src/PullRequestQuantifier.Feedback.Service/PullRequestQuantifier.Feedback.Service.csproj -c Release -o ${{env.DOTNET_ROOT}}/pullrequestquantifierfeedback
+    # - name: Deploy to Azure Web App
+    #   uses: azure/webapps-deploy@v2
+    #   with:
+    #     app-name: 'pullrequestquantifierfeedback'
+    #     slot-name: 'production'
+    #     publish-profile: ${{ secrets.AzureAppService_PublishProfile_Password }}
+    #     package: ${{env.DOTNET_ROOT}}/pullrequestquantifierfeedback

--- a/.github/workflows/feedback_service.yml
+++ b/.github/workflows/feedback_service.yml
@@ -26,10 +26,10 @@ jobs:
       run: dotnet build src/PullRequestQuantifier.Feedback.Service/PullRequestQuantifier.Feedback.Service.csproj --configuration Release --no-restore
     - name: dotnet publish
       run: dotnet publish src/PullRequestQuantifier.Feedback.Service/PullRequestQuantifier.Feedback.Service.csproj -c Release -o ${{env.DOTNET_ROOT}}/pullrequestquantifierfeedback
-    # - name: Deploy to Azure Web App
-    #   uses: azure/webapps-deploy@v2
-    #   with:
-    #     app-name: 'pullrequestquantifierfeedback'
-    #     slot-name: 'production'
-    #     publish-profile: ${{ secrets.AzureAppService_PublishProfile_Password }}
-    #     package: ${{env.DOTNET_ROOT}}/pullrequestquantifierfeedback
+    - name: Deploy to Azure Web App
+      uses: azure/webapps-deploy@v2
+      with:
+        app-name: 'pullrequestquantifierfeedback'
+        slot-name: 'production'
+        publish-profile: ${{ secrets.FEEDBACK_SERVICE_AZUREAPPSECRET }}
+        package: ${{env.DOTNET_ROOT}}/pullrequestquantifierfeedback

--- a/src/Clients/PullRequestQuantifier.Client.Tests/QuantifierResultExtensionsTests.cs
+++ b/src/Clients/PullRequestQuantifier.Client.Tests/QuantifierResultExtensionsTests.cs
@@ -75,6 +75,7 @@
                 ContextFileLink,
                 PullRequestLink,
                 AuthorName,
+                false,
                 new MarkdownCommentOptions
                 {
                     CollapseChangesSummarySection = collapseChangesSummarySection

--- a/src/Clients/PullRequestQuantifier.Client/Extensions/QuantifierResultExtensions.cs
+++ b/src/Clients/PullRequestQuantifier.Client/Extensions/QuantifierResultExtensions.cs
@@ -11,7 +11,7 @@
 
     public static class QuantifierResultExtensions
     {
-        private const string FeedbackLinkRoot = "https://compliance.ppe.startclean.microsoft.com/api/feedback?payload=";
+        private const string FeedbackLinkRoot = "https://pullrequestquantifierfeedback.azurewebsites.net/api/feedback?payload=";
 
         public static async Task<string> ToConsoleOutput(this QuantifierResult quantifierResult)
         {
@@ -43,6 +43,7 @@
             string contextFileLink,
             string pullRequestLink,
             string authorName,
+            bool anonymous = true,
             MarkdownCommentOptions markdownCommentOptions = null)
         {
             markdownCommentOptions ??= new MarkdownCommentOptions();
@@ -58,17 +59,20 @@
                 "ThumbsUp",
                 authorName,
                 repositoryLink,
-                pullRequestLink);
+                pullRequestLink,
+                anonymous);
             var feedbackLinkNeutral = CreateFeedbackLink(
                 "Neutral",
                 authorName,
                 repositoryLink,
-                pullRequestLink);
+                pullRequestLink,
+                anonymous);
             var feedbackLinkThumbsDown = CreateFeedbackLink(
                 "ThumbsDown",
                 authorName,
                 repositoryLink,
-                pullRequestLink);
+                pullRequestLink,
+                anonymous);
 
             var comment = await stubble.RenderAsync(
                 await stream.ReadToEndAsync(),
@@ -104,7 +108,8 @@
             string eventType,
             string authorName,
             string repositoryLink,
-            string pullRequestLink)
+            string pullRequestLink,
+            bool anonymous)
         {
             var payload = Base64Encode(
                 JsonConvert.SerializeObject(
@@ -116,7 +121,7 @@
                         EventType = eventType
                     }));
 
-            return $"{FeedbackLinkRoot}{payload}";
+            return $"{FeedbackLinkRoot}{payload}&anonymous={anonymous}";
         }
 
         private static string Base64Encode(string plainText)

--- a/src/Clients/PullRequestQuantifier.GitHub.Client/Events/PullRequestEventHandler.cs
+++ b/src/Clients/PullRequestQuantifier.GitHub.Client/Events/PullRequestEventHandler.cs
@@ -115,11 +115,19 @@ namespace PullRequestQuantifier.GitHub.Client.Events
                 payload.Repository.HtmlUrl,
                 quantifierContextLink,
                 payload.PullRequest.HtmlUrl,
-                payload.PullRequest.User.Login);
+                payload.PullRequest.User.Login,
+                ShouldPostAnonymousFeedbackLink(payload),
+                new MarkdownCommentOptions { CollapsePullRequestQuantifiedSection = false, CollapseChangesSummarySection = true });
             await gitHubClientAdapter.CreateIssueCommentAsync(
                 payload.Repository.Id,
                 payload.PullRequest.Number,
                 comment);
+        }
+
+        // only post anonymous feedback link in case of github.com flavor
+        private bool ShouldPostAnonymousFeedbackLink(PullRequestEventPayload payload)
+        {
+            return new Uri(payload.PullRequest.HtmlUrl).DnsSafeHost.Equals("github.com");
         }
 
         private async Task ApplyLabelToPullRequest(

--- a/src/PullRequestQuantifier.Feedback.Service/Controllers/FeedbackController.cs
+++ b/src/PullRequestQuantifier.Feedback.Service/Controllers/FeedbackController.cs
@@ -13,9 +13,9 @@ namespace PullRequestQuantifier.Feedback.Service.Controllers
     // todo move this to a separate service if the new feedback is going well.
     // todo The only reason to place it here for now is to do it have a fast deployment for the new MerlinBot feedback feature.
     // don't deal for now with Auth, we only experiment, in case is working then we can use azure API, which provides a key based auth system
-    [AllowAnonymous]
-    [Route("api/[controller]")]
     [ApiController]
+    [Route("[controller]")]
+    [Produces("application/json")]
     public class FeedbackController : ControllerBase
     {
         private readonly IBlobStorage blobStorage;

--- a/src/PullRequestQuantifier.Feedback.Service/Controllers/FeedbackController.cs
+++ b/src/PullRequestQuantifier.Feedback.Service/Controllers/FeedbackController.cs
@@ -10,9 +10,6 @@ namespace PullRequestQuantifier.Feedback.Service.Controllers
     using PullRequestQuantifier.Common.Azure.BlobStorage;
     using PullRequestQuantifier.Feedback.Service.Models;
 
-    // todo move this to a separate service if the new feedback is going well.
-    // todo The only reason to place it here for now is to do it have a fast deployment for the new MerlinBot feedback feature.
-    // don't deal for now with Auth, we only experiment, in case is working then we can use azure API, which provides a key based auth system
     [ApiController]
     [Route("[controller]")]
     [Produces("application/json")]
@@ -30,12 +27,6 @@ namespace PullRequestQuantifier.Feedback.Service.Controllers
             this.blobStorage = blobStorage;
             this.logger = logger;
             this.feedbackFormSettings = feedbackFormSettings.Value;
-        }
-
-        [HttpGet("/test")]
-        public IActionResult Test(string name)
-        {
-            return Ok(name);
         }
 
         [HttpGet]

--- a/src/PullRequestQuantifier.Feedback.Service/Controllers/FeedbackController.cs
+++ b/src/PullRequestQuantifier.Feedback.Service/Controllers/FeedbackController.cs
@@ -32,6 +32,12 @@ namespace PullRequestQuantifier.Feedback.Service.Controllers
             this.feedbackFormSettings = feedbackFormSettings.Value;
         }
 
+        [HttpGet("/test")]
+        public IActionResult Test(string name)
+        {
+            return Ok(name);
+        }
+
         [HttpGet]
         public async Task<IActionResult> Feedback(string payload, bool anonymous = true)
         {

--- a/src/PullRequestQuantifier.Feedback.Service/Models/FeedbackForm.cs
+++ b/src/PullRequestQuantifier.Feedback.Service/Models/FeedbackForm.cs
@@ -1,0 +1,9 @@
+namespace PullRequestQuantifier.Feedback.Service.Models
+{
+    public class FeedbackForm
+    {
+        public string AnonymousFormUrl { get; set; }
+
+        public string NonAnonymousFormUrl { get; set; }
+    }
+}

--- a/src/PullRequestQuantifier.Feedback.Service/PullRequestQuantifier.Feedback.Service.csproj
+++ b/src/PullRequestQuantifier.Feedback.Service/PullRequestQuantifier.Feedback.Service.csproj
@@ -1,7 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 

--- a/src/PullRequestQuantifier.Feedback.Service/PullRequestQuantifier.Feedback.Service.csproj
+++ b/src/PullRequestQuantifier.Feedback.Service/PullRequestQuantifier.Feedback.Service.csproj
@@ -1,42 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFramework>net5.0</TargetFramework>
+    </PropertyGroup>
+   
+    <ItemGroup>
+        <Content Update="appsettings.json">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </Content>
+    </ItemGroup>
 
-  <ItemGroup>
-    <None Remove="appsettings.json" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Azure.Identity" Version="1.3.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.1"/>
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="5.0.1"/>
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3"/>
+        <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.13.0"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="4.0.0"/>
+    </ItemGroup>
 
-  <ItemGroup>
-    <Content Include="appsettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </Content>
-    <Content Include="appsettings.Development.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </Content>
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="5.0.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.13.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="4.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Controllers\" />
-    <Folder Include="Models\" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\PullRequestQuantifier.Common\PullRequestQuantifier.Common.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\PullRequestQuantifier.Common\PullRequestQuantifier.Common.csproj"/>
+    </ItemGroup>
 
 </Project>

--- a/src/PullRequestQuantifier.Feedback.Service/PullRequestQuantifier.Feedback.Service.csproj
+++ b/src/PullRequestQuantifier.Feedback.Service/PullRequestQuantifier.Feedback.Service.csproj
@@ -15,6 +15,11 @@
       <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
+    <Content Include="appsettings.Development.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PullRequestQuantifier.Feedback.Service/Registrar.cs
+++ b/src/PullRequestQuantifier.Feedback.Service/Registrar.cs
@@ -18,6 +18,7 @@ namespace PullRequestQuantifier.Feedback.Service
                 .AddJsonFile($"appsettings.{environmentName}.json", true);
             string endPoint = builder.Build().GetValue<string>("ConfigEndpoint");
 
+            Console.WriteLine($"Connecting to appconfig {endPoint}");
             var managedIdentityCredential = new DefaultAzureCredential();
             builder.AddAzureAppConfiguration(
                     options =>
@@ -25,6 +26,7 @@ namespace PullRequestQuantifier.Feedback.Service
                                 new Uri(endPoint), managedIdentityCredential)
                             .ConfigureKeyVault(kv => kv.SetCredential(managedIdentityCredential)))
                 .Build();
+            Console.WriteLine($"Connected to appconfig {endPoint}");
         }
 
         internal static IServiceCollection RegisterServices(

--- a/src/PullRequestQuantifier.Feedback.Service/Registrar.cs
+++ b/src/PullRequestQuantifier.Feedback.Service/Registrar.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Logging;
+
 namespace PullRequestQuantifier.Feedback.Service
 {
     using System;
@@ -30,6 +32,7 @@ namespace PullRequestQuantifier.Feedback.Service
             this IServiceCollection serviceCollection,
             IConfiguration configuration)
         {
+            serviceCollection.AddLogging(b => b.AddConsole());
             var appConfiguration = configuration.GetSection(nameof(AppConfiguration)).Get<AppConfiguration>();
 
             serviceCollection.Configure<FeedbackForm>(configuration.GetSection(nameof(FeedbackForm)));

--- a/src/PullRequestQuantifier.Feedback.Service/Registrar.cs
+++ b/src/PullRequestQuantifier.Feedback.Service/Registrar.cs
@@ -1,11 +1,10 @@
-using Microsoft.Extensions.Logging;
-
 namespace PullRequestQuantifier.Feedback.Service
 {
     using System;
     using Azure.Identity;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
     using PullRequestQuantifier.Common.Azure.BlobStorage;
     using PullRequestQuantifier.Feedback.Service.Models;
 

--- a/src/PullRequestQuantifier.Feedback.Service/Registrar.cs
+++ b/src/PullRequestQuantifier.Feedback.Service/Registrar.cs
@@ -18,7 +18,6 @@ namespace PullRequestQuantifier.Feedback.Service
                 .AddJsonFile($"appsettings.{environmentName}.json", true);
             string endPoint = builder.Build().GetValue<string>("ConfigEndpoint");
 
-            Console.WriteLine($"Connecting to appconfig {endPoint}");
             var managedIdentityCredential = new DefaultAzureCredential();
             builder.AddAzureAppConfiguration(
                     options =>
@@ -26,7 +25,6 @@ namespace PullRequestQuantifier.Feedback.Service
                                 new Uri(endPoint), managedIdentityCredential)
                             .ConfigureKeyVault(kv => kv.SetCredential(managedIdentityCredential)))
                 .Build();
-            Console.WriteLine($"Connected to appconfig {endPoint}");
         }
 
         internal static IServiceCollection RegisterServices(

--- a/src/PullRequestQuantifier.Feedback.Service/appsettings.Development.json
+++ b/src/PullRequestQuantifier.Feedback.Service/appsettings.Development.json
@@ -1,0 +1,3 @@
+{
+    "ConfigEndpoint": "https://pullrequestquantifierdev.azconfig.io"
+}

--- a/src/PullRequestQuantifier.Feedback.Service/appsettings.json
+++ b/src/PullRequestQuantifier.Feedback.Service/appsettings.json
@@ -2,8 +2,8 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
+      "Microsoft.AspNetCore.Mvc": "Warning",
+      "Microsoft.AspNetCore.Hosting.Internal.WebHost": "Warning"
     }
   },
   "AllowedHosts": "*",


### PR DESCRIPTION
Deployed feedback service to azure. Redirecting user to microsoft form for further feedback (stars + suggestion). For microsoft usage, authentication comes for free with forms.

After this PR, feedback will go to new service. Except in merlin bot, until we upgrade the package and pass anonymous as false.

Anonymous for github.com:

![image](https://user-images.githubusercontent.com/15823341/108001708-130df900-6fa2-11eb-8df5-0b43a8ee8e10.png)


Authenticated for ADO, GHAE:

![image](https://user-images.githubusercontent.com/15823341/108001722-1ef9bb00-6fa2-11eb-9342-d0dabc1f3a68.png)
