### PR TITLE
Fixed "No Changes" label not removed when the pull request size changes

### DIFF
--- a/src/Clients/PullRequestQuantifier.GitHub.Client.Tests/Events/PullRequestEventHandlerTests.cs
+++ b/src/Clients/PullRequestQuantifier.GitHub.Client.Tests/Events/PullRequestEventHandlerTests.cs
@@ -145,7 +145,8 @@
         [Fact]
         public async Task HandleEvent_FromNoDiffToDiff_SetNewLabelCorrectly()
         {
-            var previousLabel = new Label(1L, string.Empty, "No Changes", "1", string.Empty, string.Empty, true);
+            var previousLabelName = "No Changes";
+            var previousLabel = new Label(1L, string.Empty, previousLabelName, "1", string.Empty, string.Empty, true);
             var newLabelName = "Extra Small";
             var diff = @"diff --git a/a.txt b/a.txt
 new file mode 100644
@@ -174,7 +175,7 @@ index 0000000..9daeafb
             // assert
             gitHubClientAdapter.Verify(
                 f =>
-                    f.RemoveLabelFromIssueAsync(It.IsAny<long>(), It.IsAny<int>(), "No Changes"),
+                    f.RemoveLabelFromIssueAsync(It.IsAny<long>(), It.IsAny<int>(), previousLabelName),
                 Times.Once);
 
             gitHubClientAdapter.Verify(

--- a/src/Clients/PullRequestQuantifier.GitHub.Client.Tests/Events/PullRequestEventHandlerTests.cs
+++ b/src/Clients/PullRequestQuantifier.GitHub.Client.Tests/Events/PullRequestEventHandlerTests.cs
@@ -181,5 +181,47 @@ index 0000000..9daeafb
                 f =>
                     f.ApplyLabelAsync(It.IsAny<long>(), It.IsAny<int>(), new[] { newLabelName }), Times.Once);
         }
+
+        [Fact]
+        public async Task HandleEvent_LabelSizeChanges_SetNewLabelCorrectly()
+        {
+            var previousLabelName = "Small";
+            var previousLabel = new Label(1L, string.Empty, previousLabelName, "1", string.Empty, string.Empty, true);
+            var newLabelName = "Extra Small";
+            var diff = @"diff --git a/a.txt b/a.txt
+new file mode 100644
+index 0000000..9daeafb
+--- /dev/null
++++ b/a.txt
+@@ -0,0 +1 @@
++test";
+
+            var addedFile = new PullRequestFile(string.Empty, "addedFile", string.Empty, 1, 0, 0, string.Empty, string.Empty, string.Empty, diff, "addedFile");
+
+            // setup
+            var installationEventHandler = new PullRequestEventHandler(
+                gitHubClientAdapterFactory.Object,
+                appTelemetry.Object,
+                new Mock<ILogger<PullRequestEventHandler>>().Object);
+
+            gitHubClientAdapter.Setup(f => f.GetIssueLabelsAsync(It.IsAny<long>(), It.IsAny<int>()))
+                .ReturnsAsync(new List<Label> { previousLabel });
+
+            gitHubClientAdapter.Setup(f => f.GetPullRequestFilesAsync(It.IsAny<long>(), It.IsAny<int>()))
+                .ReturnsAsync(new List<PullRequestFile> { addedFile });
+
+            // act
+            await installationEventHandler.HandleEvent(await File.ReadAllTextAsync(@"Data/PulRequestPayload.txt"));
+
+            // assert
+            gitHubClientAdapter.Verify(
+                f =>
+                    f.RemoveLabelFromIssueAsync(It.IsAny<long>(), It.IsAny<int>(), previousLabelName),
+                Times.Once);
+
+            gitHubClientAdapter.Verify(
+                f =>
+                    f.ApplyLabelAsync(It.IsAny<long>(), It.IsAny<int>(), new[] { newLabelName }), Times.Once);
+        }
     }
 }

--- a/src/Clients/PullRequestQuantifier.GitHub.Client.Tests/Events/PullRequestEventHandlerTests.cs
+++ b/src/Clients/PullRequestQuantifier.GitHub.Client.Tests/Events/PullRequestEventHandlerTests.cs
@@ -111,5 +111,75 @@
                 Times.Once);
             Assert.Equal(2, gitHubClientAdapter.Invocations.Count(i => i.Method.Name.Equals(nameof(gitHubClientAdapter.Object.GetRawFileAsync))));
         }
+
+        [Fact]
+        public async Task HandleEvent_FromDiffToNoDiff_SetNewLabelCorrectly()
+        {
+            var previousLabelName = "Small";
+            var previousLabel = new Label(1L, string.Empty, previousLabelName, "1", string.Empty, string.Empty, true);
+            var newLabelName = "No Changes";
+
+            // setup
+            var installationEventHandler = new PullRequestEventHandler(
+                gitHubClientAdapterFactory.Object,
+                appTelemetry.Object,
+                new Mock<ILogger<PullRequestEventHandler>>().Object);
+
+            gitHubClientAdapter.Setup(f => f.GetIssueLabelsAsync(It.IsAny<long>(), It.IsAny<int>()))
+                .ReturnsAsync(new List<Label> { previousLabel });
+
+            // act
+            await installationEventHandler.HandleEvent(await File.ReadAllTextAsync(@"Data/PulRequestPayload.txt"));
+
+            // assert
+            gitHubClientAdapter.Verify(
+                f =>
+                    f.RemoveLabelFromIssueAsync(It.IsAny<long>(), It.IsAny<int>(), previousLabelName),
+                Times.Once);
+
+            gitHubClientAdapter.Verify(
+                f =>
+                f.ApplyLabelAsync(It.IsAny<long>(), It.IsAny<int>(), new[] { newLabelName }), Times.Once);
+        }
+
+        [Fact]
+        public async Task HandleEvent_FromNoDiffToDiff_SetNewLabelCorrectly()
+        {
+            var previousLabel = new Label(1L, string.Empty, "No Changes", "1", string.Empty, string.Empty, true);
+            var newLabelName = "Extra Small";
+            var diff = @"diff --git a/a.txt b/a.txt
+new file mode 100644
+index 0000000..9daeafb
+--- /dev/null
++++ b/a.txt
+@@ -0,0 +1 @@
++test";
+            var addedFile = new PullRequestFile(string.Empty, "addedFile", string.Empty, 1, 0, 0, string.Empty, string.Empty, string.Empty, diff, "addedFile");
+
+            // setup
+            var installationEventHandler = new PullRequestEventHandler(
+                gitHubClientAdapterFactory.Object,
+                appTelemetry.Object,
+                new Mock<ILogger<PullRequestEventHandler>>().Object);
+
+            gitHubClientAdapter.Setup(f => f.GetIssueLabelsAsync(It.IsAny<long>(), It.IsAny<int>()))
+                .ReturnsAsync(new List<Label> { previousLabel });
+
+            gitHubClientAdapter.Setup(f => f.GetPullRequestFilesAsync(It.IsAny<long>(), It.IsAny<int>()))
+                .ReturnsAsync(new List<PullRequestFile> { addedFile });
+
+            // act
+            await installationEventHandler.HandleEvent(await File.ReadAllTextAsync(@"Data/PulRequestPayload.txt"));
+
+            // assert
+            gitHubClientAdapter.Verify(
+                f =>
+                    f.RemoveLabelFromIssueAsync(It.IsAny<long>(), It.IsAny<int>(), "No Changes"),
+                Times.Once);
+
+            gitHubClientAdapter.Verify(
+                f =>
+                    f.ApplyLabelAsync(It.IsAny<long>(), It.IsAny<int>(), new[] { newLabelName }), Times.Once);
+        }
     }
 }

--- a/src/Clients/PullRequestQuantifier.GitHub.Client.Tests/Events/PullRequestEventHandlerTests.cs
+++ b/src/Clients/PullRequestQuantifier.GitHub.Client.Tests/Events/PullRequestEventHandlerTests.cs
@@ -113,36 +113,6 @@
         }
 
         [Fact]
-        public async Task HandleEvent_FromDiffToNoDiff_SetNewLabelCorrectly()
-        {
-            var previousLabelName = "Small";
-            var previousLabel = new Label(1L, string.Empty, previousLabelName, "1", string.Empty, string.Empty, true);
-            var newLabelName = "No Changes";
-
-            // setup
-            var installationEventHandler = new PullRequestEventHandler(
-                gitHubClientAdapterFactory.Object,
-                appTelemetry.Object,
-                new Mock<ILogger<PullRequestEventHandler>>().Object);
-
-            gitHubClientAdapter.Setup(f => f.GetIssueLabelsAsync(It.IsAny<long>(), It.IsAny<int>()))
-                .ReturnsAsync(new List<Label> { previousLabel });
-
-            // act
-            await installationEventHandler.HandleEvent(await File.ReadAllTextAsync(@"Data/PulRequestPayload.txt"));
-
-            // assert
-            gitHubClientAdapter.Verify(
-                f =>
-                    f.RemoveLabelFromIssueAsync(It.IsAny<long>(), It.IsAny<int>(), previousLabelName),
-                Times.Once);
-
-            gitHubClientAdapter.Verify(
-                f =>
-                f.ApplyLabelAsync(It.IsAny<long>(), It.IsAny<int>(), new[] { newLabelName }), Times.Once);
-        }
-
-        [Fact]
         public async Task HandleEvent_FromNoDiffToDiff_SetNewLabelCorrectly()
         {
             var previousLabelName = "No Changes";

--- a/src/Clients/PullRequestQuantifier.GitHub.Client/Events/PullRequestEventHandler.cs
+++ b/src/Clients/PullRequestQuantifier.GitHub.Client/Events/PullRequestEventHandler.cs
@@ -85,12 +85,13 @@ namespace PullRequestQuantifier.GitHub.Client.Events
 
             var quantifyClient = new QuantifyClient(contextResult.context);
             var quantifierClientResult = await quantifyClient.Compute(quantifierInput);
+            var labels = quantifyClient.Context.Thresholds.Select(t => t.Label).Union(new[] { "No Changes" });
 
             await ApplyLabelToPullRequest(
                 payload,
                 gitHubClientAdapter,
                 quantifierClientResult,
-                quantifyClient.Context.Thresholds.Select(t => t.Label));
+                labels);
 
             var quantifierContextLink = !string.IsNullOrWhiteSpace(contextResult.context)
                 ? $"{payload.Repository.HtmlUrl}/blob/{payload.Repository.DefaultBranch}/{contextResult.contextPath}"

--- a/src/Clients/PullRequestQuantifier.GitHub.Client/Events/PullRequestEventHandler.cs
+++ b/src/Clients/PullRequestQuantifier.GitHub.Client/Events/PullRequestEventHandler.cs
@@ -85,7 +85,7 @@ namespace PullRequestQuantifier.GitHub.Client.Events
 
             var quantifyClient = new QuantifyClient(contextResult.context);
             var quantifierClientResult = await quantifyClient.Compute(quantifierInput);
-            var labels = quantifyClient.Context.Thresholds.Select(t => t.Label).Union(new[] { "No Changes" });
+            var labels = quantifyClient.Context.Thresholds.Select(t => t.Label).Union(new[] { Constants.NoChangesLabelName });
 
             await ApplyLabelToPullRequest(
                 payload,

--- a/src/PullRequestQuantifier.Common/Constants.cs
+++ b/src/PullRequestQuantifier.Common/Constants.cs
@@ -4,5 +4,6 @@ namespace PullRequestQuantifier.Common
     {
         public const string RootContextFilePath = "prquantifier.yaml";
         public const string GitHubFolderContextFilePath = ".github/prquantifier.yaml";
+        public const string NoChangesLabelName = "No Changes";
     }
 }

--- a/src/PullRequestQuantifier/PullRequestQuantifier.cs
+++ b/src/PullRequestQuantifier/PullRequestQuantifier.cs
@@ -2,6 +2,7 @@ namespace PullRequestQuantifier
 {
     using System;
     using System.Collections.Generic;
+    using System.ComponentModel;
     using System.Drawing;
     using System.Linq;
     using System.Threading.Tasks;
@@ -109,7 +110,7 @@ namespace PullRequestQuantifier
         {
             if (quantifierResult.QuantifiedLinesDeleted == 0 && quantifierResult.QuantifiedLinesAdded == 0)
             {
-                quantifierResult.Label = "No Changes";
+                quantifierResult.Label = Constants.NoChangesLabelName;
                 quantifierResult.Color = nameof(Color.Green);
                 return;
             }

--- a/src/PullRequestQuantifier/PullRequestQuantifier.cs
+++ b/src/PullRequestQuantifier/PullRequestQuantifier.cs
@@ -2,7 +2,6 @@ namespace PullRequestQuantifier
 {
     using System;
     using System.Collections.Generic;
-    using System.ComponentModel;
     using System.Drawing;
     using System.Linq;
     using System.Threading.Tasks;


### PR DESCRIPTION
# Description
Fixed bug #175: "No Changes" Label is not removed when the pull request size changes from no diff to some diff.

- Added "No Changes" label to existing labels to be considered for removal.
- Added NoChangesLabelName constant to hold the name of the label used when there is no diff.
Added 2 tests:
- Added test for use case when pull request change from no diff to some diff
- Added test for use case when pull request size changes.