### PR TITLE
chore: add required .NET runtime mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ context **to drive a optimal PR experience**.
 - Uses git history to provide a repository level context to the pull request
 - Provides customizations through a yaml file for fine grained behavior control
 
+### Prerequisites
+
+- [.NET 5.0 runtime](https://dotnet.microsoft.com/en-us/download/dotnet/5.0) is required for the framework to work properly.
+
 #
 
 <details open>

--- a/src/Clients/PullRequestQuantifier.VsCode.Client/pull-request-quantifier/README.md
+++ b/src/Clients/PullRequestQuantifier.VsCode.Client/pull-request-quantifier/README.md
@@ -10,6 +10,10 @@ A highly customizable framework to quantify a pull request within a repository c
 
 If your team uses GitHub for source code management, checkout the [PullRequestQuantifier GitHub app](https://github.com/marketplace/pull-request-quantifier)!
 
+### Prerequisites
+
+- [.NET 5.0 runtime](https://dotnet.microsoft.com/en-us/download/dotnet/5.0) is required for the extension to work properly.
+
 ## Usage
 
 Whenever a file is saved in VSCode, if that file is part of a git repo, the PullRequestQuantifier extension will evaluate changes


### PR DESCRIPTION
Adds .NET runtime version mentions to avoid confusion when extension is not starting up.

Issue: https://github.com/microsoft/PullRequestQuantifier/issues/182