### PR TITLE
Correct typo in comment: "upto" -> "up to"

### DIFF
--- a/.github/workflows/build_net_core.yml
+++ b/.github/workflows/build_net_core.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build-and-publish-release:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/src/Clients/PullRequestQuantifier.Client/Extensions/Mustache/QuantifierComment.mustache
+++ b/src/Clients/PullRequestQuantifier.Client/Extensions/Mustache/QuantifierComment.mustache
@@ -1,6 +1,6 @@
 ﻿### ![](https://img.shields.io/static/v1?label=Quantified&message={{EncodedLabel}}&color={{Color}})
 
-This PR has `{{FormulaLinesChanged}}` quantified lines of changes. In general, a change size of upto `{{IdealSizeUpperBound}}` lines is ideal for the best PR experience!
+This PR has `{{FormulaLinesChanged}}` quantified lines of changes. In general, a change size of up to `{{IdealSizeUpperBound}}` lines is ideal for the best PR experience!
 
 ------
 


### PR DESCRIPTION
Corrects a minor typo in the pull request comment.

Before:
> This PR has `{{FormulaLinesChanged}}` quantified lines of changes. In general, a change size of **upto** `{{IdealSizeUpperBound}}` lines is ideal for the best PR experience!

After:
> This PR has `{{FormulaLinesChanged}}` quantified lines of changes. In general, a change size of **up to** `{{IdealSizeUpperBound}}` lines is ideal for the best PR experience!